### PR TITLE
Rails tagged log support

### DIFF
--- a/lib/gelf/logger.rb
+++ b/lib/gelf/logger.rb
@@ -50,7 +50,7 @@ module GELF
     end
 
     def tagged(*new_tags)
-      tags     = formatter.current_tags
+      tags     = current_tags
       new_tags = new_tags.flatten.reject(&:blank?)
       tags.concat new_tags
       yield self

--- a/lib/gelf/logger.rb
+++ b/lib/gelf/logger.rb
@@ -68,6 +68,15 @@ module GELF
   # You can use it with Rails like this:
   #     config.logger = GELF::Logger.new("localhost", 12201, "WAN", { :facility => "appname" })
   #     config.colorize_logging = false
+  #
+  # Tagged logging (with tags from rack middleware) (order of tags is important)
+  # Adds custom gelf messages: { '_uuid_name' => <uuid>, '_remote_ip_name' => <remote_ip> }
+  #     config.log_tags = [:uuid, :remote_ip]
+  #     config.colorize_logging = false
+  #     config.logger = GELF::Logger.new("localhost", 12201, 'LAN', {
+  #       tags: [:uuid_name, :remote_ip_name], # same order as config.log_tags
+  #       facility: 'Jobmensa 2'
+  #     })
   class Logger < Notifier
     include LoggerCompatibility
   end

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -135,5 +135,42 @@ class TestLogger < Test::Unit::TestCase
       end
       @logger << "Message"
     end
+
+    context "#tagged" do
+      
+      # logger.tagged("TAG") { logger.info "Message" }
+      should "support tagged method" do
+        @logger.expects(:notify_with_level!).with do |level, hash|
+          level == GELF::INFO &&
+          hash['short_message'] == 'Message' &&
+          hash['facility'] == 'gelf-rb'
+        end
+
+        str = "TAG"
+        str.stubs(:blank?).returns(true)
+
+        @logger.tagged(str) { @logger.info "Message" }
+      end
+
+      should "set custom gelf message with tag name and tag content" do
+        # I want the first tag with name 'test_tag'
+        @logger.default_options.merge!('tags' => ['test_tag'])
+
+        @logger.expects(:notify_with_level!).with do |level, hash|
+          level == GELF::INFO &&
+          hash['short_message'] == 'Message' &&
+          hash['facility'] == 'gelf-rb' &&
+          hash['_test_tag'] == 'TAG' # TAG should be in the hash
+        end
+
+        str = "TAG"
+        str.stubs(:blank?).returns(false)
+
+        @logger.tagged(str) { @logger.info "Message" }
+
+      end
+
+    end
+
   end
 end


### PR DESCRIPTION
Hi,

I just added Rails tagged logging support (via `config.log_tags` / `default_options['tags']`), similar to `ActiveSupport::TaggedLogging`.

The Tags are added to the hash as custom gelf message (`'_tag_name' => <tag>`).

Example usage:

```ruby
config.log_tags = [:uuid, :remote_ip]
config.logger = GELF::Logger.new("localhost", 12201, 'LAN', {
    tags: [:some_name_for_uuid, :some_name_for_remote_ip] # same order as config.log_tags !
  })
```





