### PR TITLE
Unexplained error when using on JRuby and log4r-gelf

### DIFF
--- a/lib/gelf/ruby_sender.rb
+++ b/lib/gelf/ruby_sender.rb
@@ -6,15 +6,18 @@ module GELF
     def initialize(addresses)
       @addresses = addresses
       @i = 0
-      @socket = UDPSocket.open
     end
 
     def send_datagrams(datagrams)
       host, port = @addresses[@i]
       @i = (@i + 1) % @addresses.length
       datagrams.each do |datagram|
-        @socket.send(datagram, 0, host, port)
+        socket.send(datagram, 0, host, port)
       end
+    end
+    
+    def socket
+      @socket ||= UDPSocket.open
     end
   end
 end


### PR DESCRIPTION
Stack trace:
https://gist.github.com/3486823

From my examination, it shouldn't have anything to do with log4r-gelf. Something here relates to the initialization of JRuby UDPSocket, but I cannot put my finger on it exactly -- I would be very sad if this is a JRuby bug since I spent quite a long time trying to isolate it.

It looks like a concurrency problem, but it isn't, from my tests (tried ruby threads and Java Executors). It may be a concurrency problem with initialize vs send on the socket but I'm not sure.

Either case lazily initializing magically solved it.

I'll be happy if you also have some further input on why this might happen in the first place?


Thanks.
