### PR TITLE
Rails.cache doesn't send a block apparently

### DIFF
--- a/lib/gelf/logger.rb
+++ b/lib/gelf/logger.rb
@@ -15,7 +15,7 @@ module GELF
       # Ruby Logger's author is a maniac.
       message, progname = if args.count == 2
                             [args[0], args[1]]
-                          elsif args.count == 0
+                          elsif args.count == 0 and block_given?
                             [yield, default_options['facility']]
                           elsif block_given?
                             [yield, args[0]]


### PR DESCRIPTION
```
irb(main):001:0> Rails.cache.write 'testing123', 'sdfsfddf'
LocalJumpError: no block given (yield)
    from /mnt/rambaldi-production/shared/bundle/ruby/2.0.0/gems/gelf-1.4.0/lib/gelf/logger.rb:19:in `add'
    from /mnt/rambaldi-production/shared/bundle/ruby/2.0.0/gems/gelf-1.4.0/lib/gelf/logger.rb:48:in `debug'
    from /mnt/rambaldi-production/releases/20131028225144/config/initializers/graylog.rb:13:in `block in method_missing'
...
```
https://github.com/rubber/rubber/issues/410

I simply added a check for a block given. 