### PR TITLE
Allow injecting a sender.

### DIFF
--- a/lib/gelf/notifier.rb
+++ b/lib/gelf/notifier.rb
@@ -6,6 +6,7 @@ module GELF
       attr_accessor :last_chunk_id
     end
 
+    attr_accessor :sender
     attr_accessor :enabled, :collect_file_and_line, :rescue_network_errors
     attr_reader :max_chunk_size, :level, :default_options, :level_mapping
 
@@ -26,20 +27,20 @@ module GELF
       self.default_options['level'] ||= GELF::UNKNOWN
       self.default_options['facility'] ||= 'gelf-rb'
 
-      @sender = RubyUdpSender.new([[host, port]])
+      self.sender = default_options['sender'] || RubyUdpSender.new([[host, port]])
       self.level_mapping = :logger
     end
 
     # Get a list of receivers.
     #    notifier.addresses  # => [['localhost', 12201], ['localhost', 12202]]
     def addresses
-      @sender.addresses
+      sender.addresses
     end
 
     # Set a list of receivers.
     #    notifier.addresses = [['localhost', 12201], ['localhost', 12202]]
     def addresses=(addrs)
-      @sender.addresses = addrs
+      sender.addresses = addrs
     end
 
     def host
@@ -140,7 +141,7 @@ module GELF
       extract_hash(*args)
       @hash['level'] = message_level unless message_level.nil?
       if @hash['level'] >= level
-        @sender.send_datagrams(datagrams_from_hash)
+        sender.send_datagrams(datagrams_from_hash)
       end
     end
 

--- a/test/test_notifier.rb
+++ b/test/test_notifier.rb
@@ -19,6 +19,18 @@ class TestNotifier < Test::Unit::TestCase
     assert_equal 1337, n.max_chunk_size
   end
 
+  should "allow passing in a sender of our choosing" do
+    sender = mock
+    notifier = GELF::Notifier.new('host', 12345, 'WAN', 'sender' => sender)
+    assert_equal sender, notifier.sender
+  end
+
+  should "use the provided UDP sender by default" do
+    sender = mock
+    notifier = GELF::Notifier.new('host', 12345)
+    assert_kind_of GELF::RubyUdpSender, notifier.sender
+  end
+
   context "with notifier with mocked sender" do
     setup do
       Socket.stubs(:gethostname).returns('stubbed_hostname')


### PR DESCRIPTION
This is useful for adding e.g. a TCP sender which may not necessarily be packaged in gelf-rb.

Note that passing in your own sender does make the host and port a little pointless. This may be something to address in a future refactoring?