### PR TITLE
Add Ruby 2.1 to Travis. change mocha require

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1.0
   - jruby-19mode
 
 notifications:

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'test/unit'
 require 'shoulda'
-require 'mocha'
+require 'mocha/setup'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))


### PR DESCRIPTION
two small fixes. add ruby 2.1 to Travis tests. Change require of mocha to remove deprecation warings.

would be nice if you upload a new version to rubygems. So I can upload a new version into Debian.