### PR TITLE
Close UDPSocket when closing logger

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
       nokogiri (= 1.5.10)
       rake
       rdoc
-    json (1.8.0)
+    json (1.8.2)
     jwt (0.1.8)
       multi_json (>= 1.5)
     metaclass (0.0.1)

--- a/lib/gelf/logger.rb
+++ b/lib/gelf/logger.rb
@@ -4,10 +4,6 @@ module GELF
 
     attr_accessor :formatter
 
-    # Does nothing.
-    def close
-    end
-
     # Use it like Logger#add... or better not to use at all.
     def add(level, message = nil, progname = nil, &block)
       progname ||= default_options['facility']

--- a/lib/gelf/notifier.rb
+++ b/lib/gelf/notifier.rb
@@ -98,6 +98,11 @@ module GELF
       @enabled = true
     end
 
+    # Closes sender
+    def close
+      @sender.close
+    end
+
     # Same as notify!, but rescues all exceptions (including +ArgumentError+)
     # and sends them instead.
     def notify(*args)

--- a/lib/gelf/ruby_sender.rb
+++ b/lib/gelf/ruby_sender.rb
@@ -16,5 +16,9 @@ module GELF
         @socket.send(datagram, 0, host, port)
       end
     end
+
+    def close
+      @socket.close
+    end
   end
 end

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -209,5 +209,13 @@ class TestLogger < Test::Unit::TestCase
     should "have formatter attribute" do
       @logger.formatter
     end
+
+
+    context "close" do
+      should "close socket" do
+        @sender.expects(:close).once
+        @logger.close
+      end
+    end
   end
 end

--- a/test/test_notifier.rb
+++ b/test/test_notifier.rb
@@ -226,6 +226,13 @@ class TestNotifier < Test::Unit::TestCase
       end
     end
 
+    context "close" do
+      should "close sender" do
+        @sender.expects(:close).once
+        @notifier.close
+      end
+    end
+
     context "when disabled" do
       setup do
         @notifier.disable


### PR DESCRIPTION
When creating a new logger or notifier, a UDPSocket is created which opens a file descriptor.  This is not cleaned up when the logger is closed.  If a notifier is created per request in Rails, it can cause a "Too many open files" error to occur.

This pull request makes the logger.close method close the UDP socket.

There's also a minor bump in the JSON gem version to make it compatible with Ruby 2.2.x. https://github.com/flori/json/issues/229