### PR TITLE
Add TLS support for TCP protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the new GELF gem written by Alexey Palazhchenko. It is based on the old gem by Lennart Koopmann and allows you to send GELF messages to Graylog2 server instances. See [http://www.graylog2.org/about/gelf](http://www.graylog2.org/about/gelf) for more information about GELF and [http://rdoc.info/github/Graylog2/gelf-rb/master/frames](http://rdoc.info/github/Graylog2/gelf-rb/master/frames) for API documentation.
 
-Tested with Ruby 1.8.7, 1.9.x. and 2.0.x.
+Tested with Ruby 1.8.7, 1.9.x., 2.0.x and 2.1.x
 
 ![](https://travis-ci.org/Graylog2/gelf-rb.png?branch=master)
 
@@ -47,6 +47,19 @@ Since it's compatible with the Logger interface, you can also use it in your Rai
 
     # config/environments/production.rb
     config.logger = GELF::Logger.new("localhost", 12201, "WAN", { :facility => "appname" })
+
+### Sending GELF logs using TCP with TLS support
+
+An example of how to use TCP/TLS encryption with a good level of security.
+  logger = GELF::Logger.new("localhost", 12201, "WAN", :protocol: GELF::Protocol::TCP},
+    {:tls: true, :tcp_retry => "0", :check_ssl: true, :tls_version: "TLSv1_2" })
+
+Current config for tcp/tls:
+* tls: TLS option (true/**false**) to add TLS encryption for TCP protocol
+* tls_version: Force a TLS version (like "TLSv1_2") when TCP/TLS protocol is used
+* check_ssl: Check SSL trusted certificate (true/**false**) when TCP/TLS protocol is used
+* tcp_retry: Number of TCP retry to send a message (**0**: ulimited)
+* tcp_retry_ms: Number of ms to wait between each TCP retry
 
 ### Note on Patches/Pull Requests
 

--- a/lib/gelf.rb
+++ b/lib/gelf.rb
@@ -5,10 +5,6 @@ require 'digest/md5'
 
 module GELF
   SPEC_VERSION = '1.0'
-  module Protocol
-    UDP = 0
-    TCP = 1
-  end
 end
 
 require 'gelf/severity'

--- a/lib/gelf/notifier.rb
+++ b/lib/gelf/notifier.rb
@@ -7,25 +7,31 @@ module GELF
     end
 
     attr_accessor :enabled, :collect_file_and_line, :rescue_network_errors
-    attr_reader :max_chunk_size, :level, :default_options, :level_mapping
+    attr_reader :max_chunk_size, :level, :default_options, :config_options, :level_mapping
 
     # +host+ and +port+ are host/ip and port of graylog2-server.
     # +max_size+ is passed to max_chunk_size=.
     # +default_options+ is used in notify!
-    def initialize(host = 'localhost', port = 12201, max_size = 'WAN', default_options = {})
+    def initialize(host = 'localhost', port = 12201, max_size = 'WAN', default_options = {}, config_options = {})
       @enabled = true
       @collect_file_and_line = true
+
+      @@options = config_options
 
       self.level = GELF::DEBUG
       self.max_chunk_size = max_size
       self.rescue_network_errors = false
 
-      self.default_options = default_options
+      self.default_options = Hash.new
+      self.default_options = default_options unless default_options.nil?
       self.default_options['version'] = SPEC_VERSION
       self.default_options['host'] ||= Socket.gethostname
       self.default_options['level'] ||= GELF::UNKNOWN
       self.default_options['facility'] ||= 'gelf-rb'
       self.default_options['protocol'] ||= GELF::Protocol::UDP
+
+      self.config_options = Hash.new
+      self.config_options = config_options unless config_options.nil?
 
       if self.default_options['protocol'] == GELF::Protocol::TCP
         @sender = RubyTcpSender.new([[host, port]])
@@ -78,8 +84,16 @@ module GELF
                end
     end
 
+    def self.options
+      @@options
+    end
+
     def default_options=(options)
       @default_options = self.class.stringify_keys(options)
+    end
+
+    def config_options=(options)
+      @config_options = self.class.stringify_keys(options)
     end
 
     # +mapping+ may be a hash, 'logger' (GELF::LOGGER_MAPPING) or 'direct' (GELF::DIRECT_MAPPING).

--- a/lib/gelf/ruby_sender.rb
+++ b/lib/gelf/ruby_sender.rb
@@ -1,4 +1,10 @@
 module GELF
+  # Module definition for TCP
+  module Protocol
+    UDP = 0
+    TCP = 1
+  end
+
   # Plain Ruby UDP sender.
   class RubyUdpSender
     attr_accessor :addresses
@@ -22,30 +28,81 @@ module GELF
     end
   end
 
+  # TCP/TLS socket management
   class RubyTcpSocket
     attr_accessor :socket
+
+    require "socket"
+    require "openssl"
+    require "timeout"
 
     def initialize(host, port)
       @host = host
       @port = port
+      @options = Notifier.options
       connect
     end
 
     def connected?
       if not @connected
-        begin
-          if @socket.nil?
-            @socket = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
+        if defined? @options['tls'] and @options['tls'] != true
+          begin
+            if @socket.nil?
+              @socket = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
+            end
+            sockaddr = Socket.sockaddr_in(@port, @host)
+            @socket.connect_nonblock(sockaddr)
+          rescue Errno::EISCONN
+            @connected = true
+          rescue Errno::EINPROGRESS, Errno::EALREADY
+            @connected = false
+          rescue SystemCallError
+            @socket = nil
+            @connected = false
           end
-          sockaddr = Socket.sockaddr_in(@port, @host)
-          @socket.connect_nonblock(sockaddr)
-        rescue Errno::EISCONN
-          @connected = true
-        rescue Errno::EINPROGRESS, Errno::EALREADY
-          @connected = false
-        rescue SystemCallError
-          @socket = nil
-          @connected = false
+        else
+          begin
+            if @tcp.nil?
+              @tcp = Socket.new(
+                Socket::Constants::AF_INET,
+                Socket::Constants::SOCK_STREAM,
+                Socket::Constants::IPPROTO_IP
+              )
+              @tcp = TCPSocket.new @host, @port
+            end
+            if @socket.nil?
+              tls_context = OpenSSL::SSL::SSLContext.new
+              unless @options['check_ssl'].nil?
+                if @options['check_ssl'] == true
+                  tls_context.set_params({ :verify_mode=>OpenSSL::SSL::VERIFY_PEER})
+                else
+                  tls_context.set_params({ :verify_mode=>OpenSSL::SSL::VERIFY_NONE})
+                end
+              end
+              unless @options['tls_version'].nil?
+                if OpenSSL::SSL::SSLContext::METHODS.any? { |v| v.to_s.include?(@options['tls_version']) }
+                  tls_context.set_params({ :ssl_version => @options['tls_version']})
+                end
+              end
+              @socket = OpenSSL::SSL::SSLSocket.new(@tcp,tls_context)
+              @socket.sync_close = true
+              @socket.connect
+            end
+            @connected = true
+          rescue Errno::EISCONN
+            @connected = true
+          rescue Errno::EINPROGRESS, Errno::EALREADY
+            @connected = false
+          rescue Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::ECONNABORTED, Errno::ECONNREFUSED, Errno::ETIMEDOUT
+            @socket = nil
+            @connected = false
+          rescue OpenSSL::SSL::SSLError
+            @socket = nil
+            @connected = false
+          rescue SystemCallError
+            @socket = nil
+            @connected = false
+          end
         end
       end
       return @connected
@@ -53,14 +110,52 @@ module GELF
 
     def connect
       @connected = false
-      socket = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
-      sockaddr = Socket.sockaddr_in(@port, @host)
-      begin
-        socket.connect_nonblock(sockaddr)
-      rescue Errno::EISCONN
-        @connected = true
-      rescue SystemCallError
-        return false
+      if defined? @options['tls'] and @options['tls'] != true
+        socket = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
+        sockaddr = Socket.sockaddr_in(@port, @host)
+        begin
+          socket.connect(sockaddr)
+        rescue Errno::EISCONN
+          @connected = true
+        rescue SystemCallError
+          return false
+        end
+      else
+        begin
+          tcp = Socket.new(
+            Socket::Constants::AF_INET,
+            Socket::Constants::SOCK_STREAM,
+            Socket::Constants::IPPROTO_IP
+          )
+          tls_context = OpenSSL::SSL::SSLContext.new
+          unless @options['check_ssl'].nil?
+            if @options['check_ssl'] == true
+              tls_context.set_params({ :verify_mode=>OpenSSL::SSL::VERIFY_PEER})
+            else
+              tls_context.set_params({ :verify_mode=>OpenSSL::SSL::VERIFY_NONE})
+            end
+          end
+          unless @options['tls_version'].nil?
+            if OpenSSL::SSL::SSLContext::METHODS.any? { |v| v.to_s.include?(@options['tls_version']) }
+              tls_context.set_params({ :ssl_version => @options['tls_version']})
+            end
+          end
+          tcp = TCPSocket.new(@host, @port)
+          socket = OpenSSL::SSL::SSLSocket.new(tcp,tls_context)
+          socket.sync_close = true
+          socket.connect
+        rescue Errno::EISCONN
+          @connected = true
+        rescue Errno::EINPROGRESS, Errno::EWOULDBLOCK
+          return false
+        rescue Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::ECONNABORTED, Errno::ECONNREFUSED, Errno::ETIMEDOUT
+          return false
+        rescue OpenSSL::SSL::SSLError
+          return false
+        rescue SystemCallError
+          return false
+        end
+        @tcp = tcp
       end
       @socket = socket
       return true
@@ -73,8 +168,17 @@ module GELF
         false
       end
     end
+
+    def close
+      @socket.close unless @socket.nil?
+      @socket = nil
+      if !@options['tls'].nil? && @options['tls'] == true
+        @tcp = nil
+      end
+    end
   end
 
+  # Plain Ruby TCP sender.
   class RubyTcpSender
     attr_reader :addresses
 
@@ -84,17 +188,16 @@ module GELF
         s = RubyTcpSocket.new(address[0], address[1])
         @sockets.push(s)
       end
+      @options = Notifier.options
     end
 
     def addresses=(addresses)
-      addresses.each do |address|
-        found = false
-        # handle pre existing sockets
-        @sockets.each do |socket|
-          if socket.matches?(address[0], address[1])
-            found = true
-            break
-          end
+      found = false
+      # handle pre existing sockets
+      @sockets.each do |socket|
+        if socket.matches?(address[0], address[1])
+          found = true
+          break
         end
         if not found
           s = RubyTcpSocket.new(address[0], address[1])
@@ -104,25 +207,48 @@ module GELF
     end
 
     def send(message)
-      while true do
+      if @options['tcp_retry'] and @options['tcp_retry'] =~ /^\d+$/?true:false
+        max_retry = @options['tcp_retry'].to_i
+      else
+        max_retry = 0
+      end
+      if @options['tcp_retry_ms'] and @options['tcp_retry_ms'] =~ /^\d+$/?true:false
+        sleep_retry = @options['tcp_retry_ms'].to_f
+      else
+        sleep_retry = 50
+      end
+      i = 0
+      while i < max_retry || max_retry == 0 do
         sent = false
+        timeout = 1
         sockets = @sockets.map { |s|
           if s.connected?
             s.socket
+          else
+            reconnect
           end
         }
-        sockets.compact!
-        next unless not sockets.empty?
-        begin
-          result = select( nil, sockets, nil, 1)
-          if result
-            writers = result[1]
-            sent = write_any(writers, message)
+        if max_retry != 0
+          if i != 0
+            sleep(sleep_retry/1000)
           end
-          break if sent
-        rescue SystemCallError, IOError
+          i += 1
         end
+        next if sockets.compact.empty?
+        begin
+          result = select(sockets, sockets, nil, timeout)
+        rescue SystemCallError, IOError, EOFError, OpenSSL::SSL::SSLError, TypeError, Errno::EPIPE
+          reconnect
+        end
+        if result
+          writers = result[1]
+          sent = write_any(writers, message)
+          readers = result[0]
+          read = readable(readers)
+        end
+        return if sent && read
       end
+      warn 'Maximum TCP connection retry reached'
     end
 
     private
@@ -134,14 +260,45 @@ module GELF
         rescue Errno::EPIPE
           @sockets.each do |s|
             if s.socket == w
-              s.socket.close
+              s.socket.close unless s.socket.nil?
               s.socket = nil
+              @conencted=false
               s.connect
             end
           end
+          return false
         end
       end
       return false
     end
+
+    def readable(readers)
+      readers.shuffle.each do |r|
+        begin
+          r.sysread(10)
+        rescue EOFError, IOError
+          @sockets.each do |s|
+            if s.socket == r
+              s.socket.close unless s.socket.nil?
+              s.socket = nil
+              @conencted=false
+              s.connect
+            end
+          end
+          return false
+        end
+      end
+      return true
+    end
+
+    def reconnect
+      @sockets.each do |s|
+        s.socket.close unless s.socket.nil?
+        s.socket = nil
+        @conencted=false
+        s.connect
+      end
+    end
   end
+
 end


### PR DESCRIPTION
Add TLS Support:
* Add a new array config option for TLS option management
* Possible to force TLS version for higher security
* Possible to verify the certificate is trusted

Bugfix: 
* detect half-open socket by reading the socket after writing and socket error return by the server
* fix possible issue when "default_options" is nil

TCP improvement:
* Add close definition for manually closing TCP connection
* Add the possibility to set a number of retry when sending message (default unlimited)