### PR TITLE
[WIP] Feature: TLS on TCP connections (includes certificate authentication)

### DIFF
--- a/lib/gelf/logger.rb
+++ b/lib/gelf/logger.rb
@@ -37,15 +37,17 @@ module GELF
 
     # Redefines methods in +Notifier+.
     GELF::Levels.constants.each do |const|
-      class_eval <<-EOT, __FILE__, __LINE__ + 1
-        def #{const.downcase}(progname = nil, &block)   # def debug(progname = nil, &block)
-          add(GELF::#{const}, nil, progname, &block)    #   add(GELF::DEBUG, nil, progname, &block)
-        end                                             # end
+      method_name = const.downcase
+      
+      define_method(method_name) do |progname=nil, &block|
+        const_level = GELF.const_get(const)
+        add(const_level, nil, progname, &block)
+      end
 
-        def #{const.downcase}?                          # def debug?
-          GELF::#{const} >= level                       #   GELF::DEBUG >= level
-        end                                             # end
-      EOT
+      define_method("#{method_name}?") do
+        const_level = GELF.const_get(const)
+        const_level >= level
+      end
     end
 
     def <<(message)

--- a/lib/gelf/notifier.rb
+++ b/lib/gelf/notifier.rb
@@ -32,7 +32,8 @@ module GELF
       self.default_options['protocol'] ||= GELF::Protocol::UDP
 
       if self.default_options['protocol'] == GELF::Protocol::TCP
-        @sender = GELF::Transport::TCP.new([[host, port]])
+        tcp_options = self.default_options.delete('tcp') || {}
+        @sender = GELF::Transport::TCP.new([[host, port]], tcp_options)
       else
         @sender = GELF::Transport::UDP.new([[host, port]])
       end
@@ -140,6 +141,7 @@ module GELF
     end
 
   private
+
     def notify_with_level(message_level, *args)
       notify_with_level!(message_level, *args)
     rescue SocketError, SystemCallError
@@ -262,6 +264,7 @@ module GELF
       hash.keys.each do |key|
         value, key_s = hash.delete(key), key.to_s
         raise ArgumentError.new("Both #{key.inspect} and #{key_s} are present.") if hash.key?(key_s)
+        value = stringify_keys(value) if value.is_a?(Hash)
         hash[key_s] = value
       end
       hash

--- a/lib/gelf/transport/tcp.rb
+++ b/lib/gelf/transport/tcp.rb
@@ -7,65 +7,48 @@ module GELF
 
       def initialize(addresses)
         @sockets = []
-        addresses.each do |address|
-          s = GELF::Transport::TCPSocket.new(address[0], address[1])
-          @sockets.push(s)
-        end
+        @addresses = addresses.each { |a| create_socket(*a) }
       end
 
       def addresses=(addresses)
-        addresses.each do |address|
-          found = false
-          # handle pre existing sockets
-          @sockets.each do |socket|
-            if socket.matches?(address[0], address[1])
-              found = true
-              break
-            end
-          end
-          if not found
-            s = GELF::Transport::TCPSocket.new(address[0], address[1])
-            @sockets.push(s)
-          end
+        @addresses = addresses.each do |address|
+          # handle pre-existing sockets
+          next if @sockets.any? { |s| s.matches?(*address) }
+          create_socket(*address)
         end
       end
 
       def send(message)
         loop do
-          sent = false
-          sockets = @sockets.map { |s|
-            if s.connected?
-              s.socket
-            end
-          }.compact
+          sockets = @sockets.find_all(&:connected?).map(&:socket)
           next if sockets.empty?
           begin
             result = IO.select(nil, sockets, nil, 1)
-            if result
-              writers = result[1]
-              sent = write_any(writers, message)
-            end
-            break if sent
+            next if result.nil?
+            writers = result[1]
+            break if write_any(writers, message)
           rescue SystemCallError, IOError
           end
         end
       end
 
       private
+
       def write_any(writers, message)
         writers.shuffle.each do |w|
           begin
             w.write(message)
             return true
           rescue Errno::EPIPE
-            @sockets.each do |s|
-              if s.socket == w
-                s.reconnect
-              end
-            end
+            @sockets.find_all { |s| s.socket == w }.each(&:reconnect)
           end
         end
-        return false
+        false
+      end
+
+      def create_socket(host, port)
+        s = GELF::Transport::TCPSocket.new(host, port)
+        @sockets.push(s)
       end
     end
   end

--- a/lib/gelf/transport/tcp.rb
+++ b/lib/gelf/transport/tcp.rb
@@ -1,12 +1,17 @@
 require 'gelf/transport/tcp_socket'
+require 'gelf/transport/tcp_tls_socket'
 
 module GELF
   module Transport
     class TCP
       attr_reader :addresses
 
-      def initialize(addresses)
+      # supported options:
+      # keepalive [Boolean] whether to turn on TCP keepalive on the socket
+      # tls [TrueClass, FalseClass, Hash] see {GELF::Transport::TCPTLSSocket} for a list of options
+      def initialize(addresses, options={})
         @sockets = []
+        @options = sanitize_options(options)
         @addresses = addresses.each { |a| create_socket(*a) }
       end
 
@@ -34,6 +39,17 @@ module GELF
 
       private
 
+      def sanitize_options(options)
+        case options['tls']
+        when TrueClass then options['tls'] = {}
+        when FalseClass then options.delete('tls')
+        when Hash then # all is well
+        else
+          raise ArgumentError, "Unsupported TLS options type #{options['tls'].class}"
+        end
+        options
+      end
+
       def write_any(writers, message)
         writers.shuffle.each do |w|
           begin
@@ -47,7 +63,11 @@ module GELF
       end
 
       def create_socket(host, port)
-        s = GELF::Transport::TCPSocket.new(host, port)
+        s = if @options['tls']
+          GELF::Transport::TCPTLSSocket.new(host, port, @options)
+        else
+          GELF::Transport::TCPSocket.new(host, port, !!@options['keepalive'])
+        end
         @sockets.push(s)
       end
     end

--- a/lib/gelf/transport/tcp_socket.rb
+++ b/lib/gelf/transport/tcp_socket.rb
@@ -3,10 +3,11 @@ module GELF
     class TCPSocket
       attr_reader :socket
 
-      def initialize(host, port)
+      def initialize(host, port, keepalive=false)
         @host = host
         @port = port
         @socket = nil
+        @keepalive = keepalive
         @sockaddr = Socket.sockaddr_in(@port, @host)
         @connected = false
         connect
@@ -37,6 +38,7 @@ module GELF
       def socket_connect
         if @socket.nil?
           @socket = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
+          setup_keepalive if @keepalive
         end
 
         @socket.connect_nonblock(@sockaddr)
@@ -48,6 +50,14 @@ module GELF
       rescue SystemCallError
         @socket = nil
         @connected = false
+      end
+
+      def setup_keepalive
+        @socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true)
+        # It may be useful to set up more elaborate timeouts depending on the situation
+        # @socket.setsockopt(Socket::SOL_TCP, Socket::TCP_KEEPIDLE, 50)
+        # @socket.setsockopt(Socket::SOL_TCP, Socket::TCP_KEEPINTVL, 10)
+        # @socket.setsockopt(Socket::SOL_TCP, Socket::TCP_KEEPCNT, 5)
       end
     end
   end

--- a/lib/gelf/transport/tcp_socket.rb
+++ b/lib/gelf/transport/tcp_socket.rb
@@ -35,23 +35,19 @@ module GELF
       private
 
       def socket_connect
-        begin
-          if @socket.nil?
-            @socket = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
-          end
-
-          @socket.connect_nonblock(@sockaddr)
-          @connected = true
-        rescue Errno::EISCONN
-          @connected = true
-        rescue Errno::EINPROGRESS, Errno::EALREADY
-          @connected = false
-        rescue SystemCallError
-          @connected = false
-          @socket = nil
+        if @socket.nil?
+          @socket = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
         end
 
-        @connected
+        @socket.connect_nonblock(@sockaddr)
+        @connected = true
+      rescue Errno::EISCONN
+        @connected = true
+      rescue Errno::EINPROGRESS, Errno::EALREADY
+        @connected = false
+      rescue SystemCallError
+        @socket = nil
+        @connected = false
       end
     end
   end

--- a/lib/gelf/transport/tcp_tls_socket.rb
+++ b/lib/gelf/transport/tcp_tls_socket.rb
@@ -1,0 +1,119 @@
+require 'openssl'
+
+module GELF
+  module Transport
+    # Provides encryption capabilities on the socket
+    class TCPTLSSocket < TCPSocket
+      # Supported options:
+      # 'tls':
+      #   'no_default_ca' [Boolean] prevents OpenSSL from using the systems CA store.
+      #   'tls_version' [Symbol] any of :TLSv1, :TLSv1_1, :TLSv1_2 (default)
+      #   'cert' [String, IO] the client certificate file
+      #   'key' [String, IO] the key for the client certificate
+      #   'all_ciphers' [Boolean] allows any ciphers to be used, may be insecure
+      # 'keepalive' [Boolean] whether to enable TCP keepalive on the socket
+      def initialize(host, port, options)
+        options = {} if options.is_a?(TrueClass)
+        @options = options
+        super(host, port, options.delete('keepalive'))
+      end
+
+      # Overrides the socket accessor
+      alias_method :plain_socket, :socket
+      def socket
+        @ssl_socket
+      end
+
+      def reconnect
+        @ssl_socket = nil
+        super
+      end
+
+      private
+
+      def socket_connect
+        @ssl_socket = nil if @ssl_socket && @ssl_socket.closed?
+        return unless super
+        @connected = start_tls
+      rescue OpenSSL::OpenSSLError
+        @ssl_socket.sysclose
+        @ssl_socket = nil
+        @socket = nil
+        @connected = false
+        raise # probably better than swallowing it
+      end
+
+      # Initiates TLS communication on the socket
+      def start_tls
+        @ssl_socket = OpenSSL::SSL::SSLSocket.new(@socket, ssl_context)
+        @ssl_socket.sync_close = true
+        @ssl_socket.connect # nonblock raises OpenSSL::SSL::SSLErrorWaitReadable -> ?!
+        true
+      end
+
+      def ssl_context
+        @ssl_context ||= OpenSSL::SSL::SSLContext.new.tap do |ctx|
+          ctx.cert_store = ssl_cert_store
+          ctx.ssl_version = tls_version
+          ctx.verify_mode = verify_mode
+          set_certificate_and_key(ctx)
+          restrict_ciphers(ctx) unless tls_options['all_ciphers']
+        end
+      end
+
+      def set_certificate_and_key(context)
+        return unless tls_options['cert'] && tls_options['key']
+        context.cert = OpenSSL::X509::Certificate.new(resource(tls_options['cert']))
+        context.key = OpenSSL::PKey::RSA.new(resource(tls_options['key']))
+      end
+
+      # checks whether {resource} is a filename and tries to read it
+      # otherwise treats it as if it already contains certificate/key data
+      def resource(data)
+        if data.is_a?(String) && File.exists?(data)
+          File.read(data)
+        else
+          data
+        end
+      end
+
+      def tls_options
+        @tls_options ||= @options['tls'].is_a?(Hash) ? @options['tls'] : {}
+      end
+
+      # These are A-level ciphers as reported from Graylog 2.0.1 
+      # which were also available on Ruby using OpenSSL 1.0.2h
+      # A lot of AES-128-CBC based ciphers were not available
+      SECURE_CIPHERS = %w(
+                           AES128-GCM-SHA256
+                           ECDHE-RSA-AES128-GCM-SHA256
+                           DHE-RSA-AES128-GCM-SHA256
+                         ).freeze
+      def restrict_ciphers(ctx)
+        ctx.ciphers = SECURE_CIPHERS
+      end
+
+      def verify_mode
+        @options['no_verify'] ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
+      end
+
+      # SSL v2&3 are insecure, forces at least TLS v1.0 and defaults to v1.2
+      def tls_version
+        if tls_options.key?('version') &&
+            OpenSSL::SSL::SSLContext::METHODS.include?(tls_options['version']) &&
+            tls_options['version'] =~ /\ATLSv/
+          tls_options['version']
+        else
+          :TLSv1_2
+        end
+      end
+
+      def ssl_cert_store
+        OpenSSL::X509::Store.new.tap do |store|
+          # TODO: allow passing in expected server certificate and disabling system CAs
+          store.set_default_paths
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This has been successfully used with our Graylog 2.0.1 server but should be considered work in progress. I'd just like to get the discussion rolling and receive some feedback.

There are some changes in here which aren't related to TLS but which were convenient to make while the file was open anyway. If you want to extract these into a separate PR, let me know.

Changelist:

- make use of some `Enumerable` methods for more concise code
- remove unnecessary uses of `self` and a `begin` block
- fix `GELF::Transport::TCP#addresses`
- extract some magic numbers into constants
- replace `class_eval` with `define_method`
- support setting keepalive flag on TCP connections
- support TLS on TCP connections, including certificate authentication

Todo:

- [ ] Investigate why `connect_nonblock` raises `SSLErrorWaitReadable` and how to do it correctly
- [ ] Tests - any ideas how to best test TCP/TLS code? Fake socket objects come to mind.
- [ ] CLA?
- [ ] Split into separate PR for "drive-by" changes

Looking forward to hearing from you!